### PR TITLE
Corrigido erro no link do telegram

### DIFF
--- a/participe.md
+++ b/participe.md
@@ -35,7 +35,7 @@ Você pode [construir uma web melhor](https://www.mozilla.org/pt-BR/mission/) co
 
 ## Grupo no Telegram
 
-* Mozilla Brasil : <https://telegram.me/joinchat/ASpmewcYA-xPegW2kTecxg>
+* Mozilla Brasil : <https://telegram.me/sumobrasil>
 
 ## Canais de IRC
 


### PR DESCRIPTION
O link para o grupo no telegram estava errado dando erro, como uma atualização do telegram atualizei-o para o link de compartilhamento dado pelo telegram.
